### PR TITLE
Handle empty `config`.

### DIFF
--- a/serverless/service/__init__.py
+++ b/serverless/service/__init__.py
@@ -32,6 +32,8 @@ class Service(OrderedDict, yaml.YAMLObject):
             vars="${file(./variables.yml):{opt:stage, self:provider.stage}}"
         )
 
+        self.config = config if config else Configuration()
+
         provider.configure(self)
         self.provider = provider
 


### PR DESCRIPTION
Handle situation when `config=None`, as in this case we get:
```
AttributeError: 'NoneType' object has no attribute 'domain'
```

Code to reproduce:
```
from serverless import Service
from serverless.provider import AWSProvider

service = Service(
    "service-name",
    "some dummy service",
    AWSProvider()
)
with open("./serverless.new.yml", "w") as f:
    service.render(f)
```