### PR TITLE
Few fixes

### DIFF
--- a/serverless/aws/features/__init__.py
+++ b/serverless/aws/features/__init__.py
@@ -1,1 +1,2 @@
 from .xray import XRay
+from .api_handler import DefaultFourHundredResponse

--- a/serverless/aws/features/__init__.py
+++ b/serverless/aws/features/__init__.py
@@ -1,2 +1,3 @@
 from .xray import XRay
 from .api_handler import DefaultFourHundredResponse
+from .event_dispatcher import DLQ as EventDispatcherDLQ

--- a/serverless/aws/features/__init__.py
+++ b/serverless/aws/features/__init__.py
@@ -1,3 +1,2 @@
 from .xray import XRay
 from .api_handler import DefaultFourHundredResponse
-from .event_dispatcher import DLQ as EventDispatcherDLQ

--- a/serverless/aws/features/api_handler.py
+++ b/serverless/aws/features/api_handler.py
@@ -1,0 +1,18 @@
+from troposphere.apigateway import GatewayResponse
+
+from serverless.service.types import Feature
+
+
+class DefaultFourHundredResponse(Feature):
+    def enable(self, service):
+        service.resources.add(
+            GatewayResponse(
+                "GatewayResponseDefault4XX",
+                ResponseParameters={
+                    "gatewayresponse.header.Access-Control-Allow-Origin": "*",
+                    "gatewayresponse.header.Access-Control-Allow-Headers": "*",
+                },
+                ResponseType="DEFAULT_4XX",
+                RestApiId="!Ref ApiGatewayRestApi",
+            )
+        )

--- a/serverless/aws/features/event_dispatcher.py
+++ b/serverless/aws/features/event_dispatcher.py
@@ -1,0 +1,31 @@
+from troposphere import GetAtt
+from troposphere.cloudwatch import Alarm, MetricDimension
+from troposphere.sqs import Queue
+
+from serverless.service.types import Feature
+
+
+class DLQ(Feature):
+    def enable(self, service):
+        service.resources.add(
+            Queue(
+                "EventDispatcherDLQ",
+                QueueName="${self:service}-event-dispatcher-dlq",
+                MessageRetentionPeriod=1209600  # 14 days in seconds
+            )
+        )
+        service.resources.add(
+            Alarm(
+                "EventDispatcherDLQCloudWatchAlarm",
+                AlarmDescription="Unable to send event from handler.",
+                AlarmActions=["arn:aws:sns:${aws:region}:${aws:accountId}:foxglove-${self:custom.stage}-cloudwatch-alerts"],
+                Namespace="AWS/SQS",
+                MetricName="ApproximateNumberOfMessagesVisible",
+                Dimensions=[MetricDimension(Name="QueueName", Value=GetAtt("EventDispatcherDLQ", "QueueName"))],
+                Statistic="Sum",
+                Period=60,
+                EvaluationPeriods=1,
+                Threshold=1,
+                ComparisonOperator="GreaterThanOrEqualToThreshold",
+            )
+        )

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -14,7 +14,7 @@ class Function(YamlOrderedDict):
         self.description = description
 
         if not handler:
-            handler = f"{self._service.service.snake}/{stringcase.snakecase(name)}.handler"
+            handler = f"{self._service.service.snake}.{stringcase.snakecase(name)}.handler"
 
         self.handler = handler
         self.events = []

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -1,7 +1,7 @@
 from serverless.aws.types import SQSArn
 from serverless.service.types import Identifier, YamlOrderedDict
 from troposphere.sqs import Queue
-
+import stringcase
 
 class Function(YamlOrderedDict):
     yaml_tag = "!Function"
@@ -9,11 +9,12 @@ class Function(YamlOrderedDict):
     def __init__(self, service, name, description, handler=None, timeout=None, layers=None, **kwargs):
         super().__init__()
         self._service = service
-        self.name = Identifier(name)
+        self.key = stringcase.camelcase(stringcase.spinalcase(name).lower())
+        self.name =  Identifier(self._service.service.spinal.lower() + "-" + stringcase.spinalcase(name).lower())
         self.description = description
 
         if not handler:
-            handler = f"{self._service.service.snake}/{self.name.snake}:handler"
+            handler = f"{self._service.service.snake}/{stringcase.snakecase(name)}.handler"
 
         self.handler = handler
         self.events = []
@@ -45,6 +46,7 @@ class Function(YamlOrderedDict):
     def to_yaml(cls, dumper, data):
         events = data.events
         data.pop("_service", None)
+        data.pop("key", None)
 
         data.events = [{event.yaml_tag: event} for event in events]
 

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -9,7 +9,7 @@ class Function(YamlOrderedDict):
     def __init__(self, service, name, description, handler=None, timeout=None, layers=None, **kwargs):
         super().__init__()
         self._service = service
-        self.key = stringcase.camelcase(stringcase.spinalcase(name).lower())
+        self.key = stringcase.pascalcase(stringcase.snakecase(name).lower())
         self.name =  Identifier(self._service.service.spinal.lower() + "-" + stringcase.spinalcase(name).lower())
         self.description = description
 

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -10,7 +10,7 @@ class Function(YamlOrderedDict):
         super().__init__()
         self._service = service
         self.key = stringcase.pascalcase(stringcase.snakecase(name).lower())
-        self.name =  Identifier(self._service.service.spinal.lower() + "-" + stringcase.spinalcase(name).lower())
+        self.name = Identifier(self._service.service.spinal.lower() + "-" + stringcase.spinalcase(name).lower())
         self.description = description
 
         if not handler:

--- a/serverless/aws/functions/http.py
+++ b/serverless/aws/functions/http.py
@@ -26,6 +26,7 @@ class HTTPEvent(YamlOrderedDict):
         if request_parameters_querystrings:
             self.request = {"parameters": {"querystrings": request_parameters_querystrings}}
 
+
 class HTTPFunction(Function):
     yaml_tag = "!HTTPFunction"
 
@@ -37,7 +38,7 @@ class HTTPFunction(Function):
     ANY = "ANY"
 
     def __init__(
-        self, service, name, description, path, method, authorizer=None, handler=None, timeout=None, layers=None, **kwargs
+        self, service, name, description, path, method, authorizer=None, handler=None, timeout=None, layers=None, request_parameters_querystrings=None, **kwargs
     ):
         super().__init__(service, name, description, handler, timeout, layers, **kwargs)
-        self.trigger(HTTPEvent(path, method, authorizer))
+        self.trigger(HTTPEvent(path, method, authorizer, request_parameters_querystrings))

--- a/serverless/aws/functions/http.py
+++ b/serverless/aws/functions/http.py
@@ -15,7 +15,7 @@ class HTTPAuthorizer(YamlOrderedDict):
 class HTTPEvent(YamlOrderedDict):
     yaml_tag = "http"
 
-    def __init__(self, path, method, authorizer=None):
+    def __init__(self, path, method, authorizer=None, request_parameters_querystrings=None):
         super().__init__()
         self.path = path
         self.method = method
@@ -23,6 +23,8 @@ class HTTPEvent(YamlOrderedDict):
         if authorizer:
             self.authorizer = authorizer
 
+        if request_parameters_querystrings:
+            self.request = {"parameters": {"querystrings": request_parameters_querystrings}}
 
 class HTTPFunction(Function):
     yaml_tag = "!HTTPFunction"

--- a/serverless/aws/iam/secrets_manager.py
+++ b/serverless/aws/iam/secrets_manager.py
@@ -1,0 +1,13 @@
+from serverless.aws.iam import IAMPreset
+
+
+class SecretsManagerReader(IAMPreset):
+    def __init__(self, resource):
+        super().__init__(resource)
+
+    def apply(self, service):
+        service.provider.iam.allow(
+            "secretsmanager",
+            ["secretsmanager:GetSecretValue"],
+            "arn:aws:secretsmanager:${aws:region}:${aws:accountId}:secret:"+self.resource,
+        )

--- a/serverless/aws/provider.py
+++ b/serverless/aws/provider.py
@@ -80,11 +80,9 @@ class Provider(BaseProvider, yaml.YAMLObject):
     yaml_tag = "!Provider"
 
     def __init__(
-            self, runtime=Runtime.PYTHON_3_8, extra_tags=None, timeout=60, stage="development", environment=None, /,
-            **kwds
+            self, runtime=Runtime.PYTHON_3_8, extra_tags=None, timeout=60, stage="development", environment=None, **kwargs
     ):
-        super().__init__(**kwds)
-
+        super().__init__(**kwargs)
         self.deploymentBucket = None
         self._service = None
         self.function_builder = None

--- a/serverless/aws/provider.py
+++ b/serverless/aws/provider.py
@@ -109,7 +109,7 @@ class Provider(BaseProvider, yaml.YAMLObject):
             name=f"sls-deployments.${{self:custom.region}}."
                  f"${{self:custom.stage}}{self._service.config.domain(prefix='.')}"
         )
-        self.tags["SERVICE"] = self._service.service.spinal
+        self.tags["SERVICE"] = "${self:service}"
         self.iam = IAMManager(self._service)
         self.function_builder = FunctionBuilder(self._service)
 

--- a/serverless/integration/__init__.py
+++ b/serverless/integration/__init__.py
@@ -1,0 +1,1 @@
+from .event_dispatcher import DLQ as EventDispatcherDLQIntegration

--- a/serverless/integration/event_dispatcher.py
+++ b/serverless/integration/event_dispatcher.py
@@ -29,3 +29,8 @@ class DLQ(Feature):
                 ComparisonOperator="GreaterThanOrEqualToThreshold",
             )
         )
+        service.provider.iam.allow(
+            "EventDispatcherDQLBatch",
+            "sqs:SendMessageBatch",
+            [{"Fn::GetAtt": ["EventDispatcherDLQ", "Arn"]}]
+        )

--- a/serverless/service/__init__.py
+++ b/serverless/service/__init__.py
@@ -27,9 +27,9 @@ class Service(OrderedDict, yaml.YAMLObject):
         self.package = Package(["!./**/**", f"{self.service.snake}/**"])
         self.variablesResolutionMode = 20210326
         self.custom = YamlOrderedDict(
-            stage="${opt:stage, self:provider.stage}",
+            stage="${sls:stage}",
             region="${opt:region, 'us-east-1'}",
-            vars="${file(./variables.yml):{opt:stage, self:provider.stage}}"
+            vars="${file(./variables.yml):${sls:stage}}"
         )
 
         self.config = config if config else Configuration()

--- a/serverless/service/environment.py
+++ b/serverless/service/environment.py
@@ -4,6 +4,11 @@ from serverless.service.types import YamlOrderedDict
 class Environment(YamlOrderedDict):
     yaml_tag = "Environment"
 
+    def __init__(self, envs=None):
+        super().__init__()
+        if envs:
+            self.envs = envs
+
     @classmethod
     def to_yaml(cls, dumper, data):
-        return dumper.represent_dict(data)
+        return dumper.represent_dict(data.envs)

--- a/serverless/service/functions.py
+++ b/serverless/service/functions.py
@@ -17,4 +17,4 @@ class FunctionManager(yaml.YAMLObject):
 
     @classmethod
     def to_yaml(cls, dumper, data):
-        return dumper.represent_dict({function.name.pascal: function for function in data.functions})
+        return dumper.represent_dict({function.key: function for function in data.functions})

--- a/serverless/service/plugins/domain_manager.py
+++ b/serverless/service/plugins/domain_manager.py
@@ -2,8 +2,17 @@ from serverless.service.plugins.generic import Generic
 
 
 class DomainManager(Generic):
+    """
+    Plugin homepage: https://github.com/amplify-education/serverless-domain-manager
+    """
     yaml_tag = u"!DomainManagerPlugin"
 
     def __init__(self, domain, api="rest", stage="${self:custom.stage}", basePath=None, createRoute53Record=False):
         super().__init__("serverless-domain-manager")
         self[api] = dict(domain=domain, stag=stage, basePath=basePath, createRoute53Record=createRoute53Record)
+
+    def enable(self, service):
+        export = dict(self)
+        export.pop("name", None)
+
+        service.custom.customDomain = export

--- a/serverless/service/plugins/vpc_discovery.py
+++ b/serverless/service/plugins/vpc_discovery.py
@@ -14,7 +14,7 @@ class VpcDiscovery(Generic):
     def __init__(self, vpc_name, subnet_names=None, subnets=None, security_group_names=None, security_groups=None):
         super().__init__("serverless-vpc-discovery")
 
-        self.vpc_name = vpc_name
+        self.vpcName = vpc_name
         if all((subnet_names, subnets)):
             raise Exception("You can use either subnet_names or subnets.")
         if all((security_group_names, security_groups)):
@@ -32,7 +32,7 @@ class VpcDiscovery(Generic):
                 {"tagKey": "Name", "tagValues": security_group_names}
             ]
         if security_groups:
-            self.security_groups = security_groups
+            self.securityGroups = security_groups
 
     def enable(self, service):
         export = dict(self)


### PR DESCRIPTION
- Allow to pass request parameters for HTTPEvent
- Remove / from __init__ to allow pass params.
- Make sure that Environment is dumped correctly
- Use . (dot) rather than / (slash) for handler.
- Change the way function name is generated. 
- Fix DomainManager.
- Use dynamicaly service name for tags.
- Allow to use raw statements
- Added `EventDispatcherDLQ`