### PR TITLE
Allow easy duplication of HTTP events with different path/method

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ service.provider.iam.apply(DynamoDBReader(table))
 service.builder.function.generic("test", "description")
 service.builder.function.http("test", "description", "/", HTTPFunction.POST)
 
+# Multiple events with different paths and/or methods can be set up for the same handler:
+service.builder.function.http("test", "description", ["/", "/alias"], ["POST", "PUT"], handler="shared.handler")
+# This will add the same handler to all of these: POST /, POST /alias, PUT /, PUT /alias
+
 event_bridge_function = service.builder.function.event_bridge(
     "event_bridge_function",
     "sample event bridge function",

--- a/serverless/aws/functions/http.py
+++ b/serverless/aws/functions/http.py
@@ -1,3 +1,5 @@
+import itertools
+
 from serverless.aws.functions.generic import Function
 from serverless.service.types import YamlOrderedDict
 
@@ -52,4 +54,12 @@ class HTTPFunction(Function):
         **kwargs
     ):
         super().__init__(service, name, description, handler, timeout, layers, **kwargs)
-        self.trigger(HTTPEvent(path, method, authorizer, request_parameters_querystrings))
+
+        if isinstance(path, str):
+            path = [path]
+        if isinstance(method, str):
+            method = [method]
+
+        # Set up an HTTP event on all combinations of path and method
+        for p, m in itertools.product(path, method):
+            self.trigger(HTTPEvent(p, m, authorizer, request_parameters_querystrings))


### PR DESCRIPTION
Sometimes the same function has to handle multiple events. Although it is not a common design to enable multiple different events for a single function, in the case of HTTP endpoints it is completely normal to have multiple methods of paths served in the same handler, for example sharing functionality for POST and PUT, allowing path aliases, or supporting a transient state during a migration to a different path when the same functionality is required under different resource paths.

This change aims to implement the above idea by allowing either a single `str` or an iterable of `str` as path and method for HTTP events. The default functionality doesn't change, but when more than 1 path or method is given then a duplicate instance of the same event is attached to the function with each path/method combination.

Usage example:

```python
# Single HTTP event
service.builder.function.http("test", "description", "/", HTTPFunction.POST)

# 2 HTTP events, same handler but different resource path:
service.builder.function.http("test", "description", ["/", "/alias"], HTTPFunction.POST, handler="shared.handler")

# Multiple HTTP events for the combinations: POST /, POST /alias, PUT /, PUT /alias
service.builder.function.http("test", "description", ["/", "/alias"], ["POST", "PUT"], handler="shared.handler")
```