### PR TITLE
Add `dynamodb:Scan` for `DynamoDBReader`.

### DIFF
--- a/serverless/aws/iam/dynamodb.py
+++ b/serverless/aws/iam/dynamodb.py
@@ -12,8 +12,9 @@ class DynamoDBReader(IAMPreset):
         service.provider.iam.allow(
             sid,
             [
-                "dynamodb:Query",
                 "dynamodb:GetItem",
+                "dynamodb:Query",
+                "dynamodb:Scan",
             ],
             [self.resource.get_att("Arn").to_dict()],
         )


### PR DESCRIPTION
Our actions allow to choose between `scan` and `query`, but default list of permissions didn't include `scan`.