### PR TITLE
Use domain name from config.

### DIFF
--- a/serverless/aws/provider.py
+++ b/serverless/aws/provider.py
@@ -171,9 +171,8 @@ class Provider(BaseProvider, yaml.YAMLObject):
 
     def configure(self, service):
         self._service = service
-        self.deploymentBucket = dict(
-            name=f'sls-deployments.${{aws:region}}.${{sls:stage}}.${{self:custom.vars.domain, "app"}}'
-        )
+        if service.config.domain:
+            self.deploymentBucket = dict(name=f"sls-deployments.${{aws:region}}.${{sls:stage}}.{service.config.domain}")
         self.tags["SERVICE"] = "${self:service}"
         self.iam = IAMManager(self._service)
         self.function_builder = FunctionBuilder(self._service)
@@ -182,5 +181,7 @@ class Provider(BaseProvider, yaml.YAMLObject):
     def to_yaml(cls, dumper, data):
         data.pop("_service", None)
         data.pop("function_builder", None)
+        if not data["deploymentBucket"]:
+            data.pop("deploymentBucket", None)
 
         return dumper.represent_dict(data)

--- a/serverless/service/configuration.py
+++ b/serverless/service/configuration.py
@@ -3,4 +3,4 @@ from serverless.service.types import SmartString
 
 class Configuration:
     def __init__(self, domain=None):
-        self.domain = SmartString(domain)
+        self.domain = SmartString(domain) if domain else None


### PR DESCRIPTION
Instead of dynamically defined domain we can use one used in configuration.

In case domain is not provided `serverless` will generate one.