### PR TITLE
Automatically add `-??????` to SecretManager ARN

### DIFF
--- a/serverless/aws/iam/secrets_manager.py
+++ b/serverless/aws/iam/secrets_manager.py
@@ -6,8 +6,10 @@ class SecretsManagerReader(IAMPreset):
         super().__init__(resource)
 
     def apply(self, service):
+        resource = str(self.resource) if self.resource.endswith("-??????") else f"{self.resource}-??????"
+
         service.provider.iam.allow(
             "secretsmanager",
             ["secretsmanager:GetSecretValue"],
-            "arn:aws:secretsmanager:${aws:region}:${aws:accountId}:secret:" + self.resource,
+            "arn:aws:secretsmanager:${aws:region}:${aws:accountId}:secret:" + resource,
         )


### PR DESCRIPTION
SecretManager ARN is constructed the way its postfix is auto generated. You can replace that with question marks. This change automatically adds it if not passed as secret name.