### PR TITLE
Add a way to force name of function.

### DIFF
--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -9,13 +9,16 @@ from serverless.service.types import Identifier, YamlOrderedDict
 class Function(YamlOrderedDict):
     yaml_tag = "!Function"
 
-    def __init__(self, service, name, description, handler=None, timeout=None, layers=None, **kwargs):
+    def __init__(self, service, name, description, handler=None, timeout=None, layers=None, force_name=None, **kwargs):
         super().__init__()
         self._service = service
         self.key = stringcase.pascalcase(stringcase.snakecase(name).lower())
-        self.name = Identifier(
-            self._service.service.spinal.lower() + "-${sls:stage}" + "-" + stringcase.spinalcase(name).lower()
-        )
+        if force_name:
+            self.name = force_name
+        else:
+            self.name = Identifier(
+                self._service.service.spinal.lower() + "-${sls:stage}" + "-" + stringcase.spinalcase(name).lower()
+            )
         self.description = description
 
         if not handler:


### PR DESCRIPTION
You might have cases where you need to force name of function rather than relay on auto generated one.

This covers this situation.