### PR TITLE
Default `Provider` initialization values for `timeout` and `stage`

### DIFF
--- a/serverless/aws/provider.py
+++ b/serverless/aws/provider.py
@@ -150,7 +150,7 @@ class Provider(BaseProvider, yaml.YAMLObject):
     yaml_tag = "!Provider"
 
     def __init__(
-        self, runtime=Runtime.PYTHON_3_8, extra_tags=None, timeout=60, stage="${opt:stage}", environment=None, **kwargs
+        self, runtime=Runtime.PYTHON_3_8, extra_tags=None, timeout=10, stage="${opt:stage}", environment=None, **kwargs
     ):
         super().__init__(**kwargs)
         self.deploymentBucket = None

--- a/serverless/aws/provider.py
+++ b/serverless/aws/provider.py
@@ -150,7 +150,7 @@ class Provider(BaseProvider, yaml.YAMLObject):
     yaml_tag = "!Provider"
 
     def __init__(
-        self, runtime=Runtime.PYTHON_3_8, extra_tags=None, timeout=10, stage="development", environment=None, **kwargs
+        self, runtime=Runtime.PYTHON_3_8, extra_tags=None, timeout=60, stage="${opt:stage}", environment=None, **kwargs
     ):
         super().__init__(**kwargs)
         self.deploymentBucket = None


### PR DESCRIPTION
Changes default `Provider` initialization values for `timeout` and `stage` params as suggested [here](https://github.com/epsyhealth/user-attribution/pull/5#discussion_r808776930).

```
... timeout=60, stage="${opt:stage}" ...
```