### PR TITLE
Updates self.onError attribute assignment.

### DIFF
--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -70,8 +70,7 @@ class Function(YamlOrderedDict):
                 permissions=["sqs:GetQueueUrl", "sqs:SendMessageBatch", "sqs:SendMessage"],
                 resources=[onErrorDLQArn],
             )
-
-        self.onError = onErrorDLQArn
+        self.onError = {"Fn::Sub": onErrorDLQArn}
 
     def use_destination_dlq(self, onFailuredlqArn: Optional[str] = None, MessageRetentionPeriod: int = 1209600) -> None:
         """


### PR DESCRIPTION
Fixes an issue where `onError: arn:aws:...` field format caused failing template validation:

```
Error:
Configuration error: 
     at 'functions.XYZ.onError': unsupported string format
```
[
Slack thread.](https://epsy-workspace.slack.com/archives/C01439R74D6/p1645518901763079)