### PR TITLE
Add basic support for StepFunctions 

### DIFF
--- a/serverless/aws/features/stepfunctions.py
+++ b/serverless/aws/features/stepfunctions.py
@@ -87,8 +87,9 @@ class Iterator(YamlOrderedDict):
 class Map(Stage):
     yaml_tag = "!Map"
 
-    def __init__(self, name, steps, items_path="$.items", input_path="$.body", result_path="$.results", concurrency=20,
-                 end=False):
+    def __init__(
+        self, name, steps, items_path="$.items", input_path="$.body", result_path="$.results", concurrency=20, end=False
+    ):
         super().__init__("Map")
         self.name = name
         self.InputPath = input_path
@@ -163,7 +164,7 @@ class StateMachine(YamlOrderedDict):
 
 
 class StepFunctions(YamlOrderedDict):
-    yaml_tag = '!StepFunctions'
+    yaml_tag = "!StepFunctions"
 
     def __init__(self):
         self.validate = True

--- a/serverless/aws/features/stepfunctions.py
+++ b/serverless/aws/features/stepfunctions.py
@@ -1,0 +1,186 @@
+from serverless.service.types import YamlOrderedDict
+
+
+class Stage(YamlOrderedDict):
+    yaml_tag = "!Stage"
+
+    def __init__(self, type, function=None):
+        self.Type = type
+        self._function = function
+
+    def next(self, stage):
+        self.Next = stage.id
+
+    @property
+    def id(self):
+        return self._function.key
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        data.pop("_function", None)
+        return super().to_yaml(dumper, data)
+
+
+class Fallback(Stage):
+    yaml_tag = "!Fallback"
+
+    def __init__(self, name, result):
+        super().__init__("Pass")
+        self.Result = result
+        self.End = True
+        self._name = name
+
+    @property
+    def id(self):
+        return self._name
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        data.pop("_name")
+        return super().to_yaml(dumper, data)
+
+
+class Task(Stage):
+    yaml_tag = "!Task"
+
+    def __init__(self, function, end=None):
+        super().__init__("Task", function)
+
+        self.Resource = function.arn()
+        if end is not None:
+            self.End = end
+
+
+class Iterator(YamlOrderedDict):
+    yaml_tag = "!Iterator"
+
+    def __init__(self, map_name, steps):
+        self.States = {step.id: step for step in steps}
+        self.map_name = map_name
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        data["StartAt"] = list(data.States.keys())[0]
+        data.move_to_end("StartAt", last=False)
+
+        fallback = None
+        for step in data.States.values():
+            if step.get("Type") in ("Pass", "Fail"):
+                fallback = step
+                break
+
+        if not fallback:
+            fallback = Fallback(f"{data.map_name}Fallback", f"Failed processing map: {data.map_name}")
+            data["States"][fallback.id] = fallback
+
+        for step in data.States.values():
+            if step.get("Catch") or step.get("Type") in ("Pass", "Fail", "Map"):
+                continue
+
+            step["Catch"] = [{"ErrorEquals": ["States.ALL"], "Next": fallback.id}]
+
+        data.pop("map_name", None)
+
+        return super().to_yaml(dumper, data)
+
+
+class Map(Stage):
+    yaml_tag = "!Map"
+
+    def __init__(self, name, steps, items_path="$.items", input_path="$.body", result_path="$.results", concurrency=20,
+                 end=False):
+        super().__init__("Map")
+        self.name = name
+        self.InputPath = input_path
+        self.ItemsPath = items_path
+        self.ResultPath = result_path
+        self.MaxConcurrency = concurrency
+        self.End = end
+        self.Iterator = Iterator(name, steps)
+
+    @property
+    def id(self):
+        return self.name
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        data.pop("name", None)
+        return super().to_yaml(dumper, data)
+
+
+class Definition(YamlOrderedDict):
+    yaml_tag = "!Definition"
+
+    def __init__(self, description):
+        self.Comment = description
+        self.States = YamlOrderedDict()
+
+    def add(self, state):
+        self.States[state.id] = state
+
+        return state
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        data["StartAt"] = list(data.States.keys())[0]
+        data.move_to_end("StartAt", last=False)
+
+        fallback = None
+        for step in data.States.values():
+            if step.get("Type") in ("Pass", "Fail"):
+                fallback = step
+                break
+
+        if not fallback:
+            fallback = Fallback("StateMachineErrorFallback", "Error in state machine")
+            data.add(fallback)
+
+        for step in data.States.values():
+            if step.get("Catch") or step.get("Type") in ("Pass", "Fail", "Map"):
+                continue
+
+            step["Catch"] = [{"ErrorEquals": ["States.ALL"], "Next": fallback.id}]
+
+        return super().to_yaml(dumper, data)
+
+
+class StateMachine(YamlOrderedDict):
+    yaml_tag = "!YamlOrderedDict"
+
+    def __init__(self, name, description, events=None):
+        self.name = name
+        self.definition = Definition(description)
+        self.events = events or []
+
+    def task(self, function):
+        return self.definition.add(Task(function))
+
+    def map(self, name, steps, **kwargs):
+        return self.definition.add(Map(name, steps, **kwargs))
+
+    def event(self, event):
+        self.events.append(event)
+
+
+class StepFunctions(YamlOrderedDict):
+    yaml_tag = '!StepFunctions'
+
+    def __init__(self):
+        self.validate = True
+        self.stateMachines = YamlOrderedDict()
+
+    def machine(self, name, description):
+        if name in self.stateMachines:
+            return self.stateMachines.get(name)
+
+        machine = StateMachine(name, description)
+        self.stateMachines[name] = machine
+
+        return machine
+
+
+class Scheduled(YamlOrderedDict):
+    yaml_tag = "!YamlOrderedDict"
+
+    def __init__(self, expression):
+        self.schedule = expression

--- a/serverless/aws/features/stepfunctions.py
+++ b/serverless/aws/features/stepfunctions.py
@@ -166,7 +166,8 @@ class StateMachine(YamlOrderedDict):
 class StepFunctions(YamlOrderedDict):
     yaml_tag = "!StepFunctions"
 
-    def __init__(self):
+    def __init__(self, service):
+        self.service = service
         self.validate = True
         self.stateMachines = YamlOrderedDict()
 
@@ -174,10 +175,15 @@ class StepFunctions(YamlOrderedDict):
         if name in self.stateMachines:
             return self.stateMachines.get(name)
 
-        machine = StateMachine(name, description)
+        machine = StateMachine(f"{self.service}-{name}", description)
         self.stateMachines[name] = machine
 
         return machine
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        data.pop("service", None)
+        return super().to_yaml(dumper, data)
 
 
 class Scheduled(YamlOrderedDict):

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -87,7 +87,7 @@ class Function(YamlOrderedDict):
             self._service.provider.iam.allow(
                 sid=f"{queue.title}Writer",
                 permissions=["sqs:GetQueueUrl", "sqs:SendMessageBatch", "sqs:SendMessage"],
-                resources=[onErrorDLQArn],
+                resources=[str(onErrorDLQArn)],
             )
         self.onError = {"Fn::Sub": onErrorDLQArn}
 

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -58,6 +58,15 @@ class Function(YamlOrderedDict):
         for name, value in kwargs.items():
             setattr(self, name, value)
 
+    def get_attr(self, attr):
+        return {"Fn::GetAtt": [self.resource_name(), attr]}
+
+    def arn(self):
+        return self.get_attr("Arn")
+
+    def resource_name(self):
+        return f"{self.key}LambdaFunction"
+
     def trigger(self, event):
         self.events.append(event)
 

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -19,7 +19,18 @@ from serverless.service.types import Identifier, YamlOrderedDict
 class Function(YamlOrderedDict):
     yaml_tag = "!Function"
 
-    def __init__(self, service, name, description, handler=None, timeout=None, layers=None, force_name=None, idempotency=None, **kwargs):
+    def __init__(
+        self,
+        service,
+        name,
+        description,
+        handler=None,
+        timeout=None,
+        layers=None,
+        force_name=None,
+        idempotency=None,
+        **kwargs,
+    ):
         super().__init__()
         self._service = service
 
@@ -124,9 +135,7 @@ class Function(YamlOrderedDict):
 
     def with_vpc(self, security_group_names=None, subnet_names=None):
         if security_group_names:
-            self.vpcDiscovery = dict(
-                securityGroups=[dict(tagKey="Name", tagValues=security_group_names.copy())]
-            )
+            self.vpcDiscovery = dict(securityGroups=[dict(tagKey="Name", tagValues=security_group_names.copy())])
 
         return self
 

--- a/serverless/aws/iam/apigw.py
+++ b/serverless/aws/iam/apigw.py
@@ -16,5 +16,7 @@ class Execute(IAMPreset):
             arn = self.endpoint
 
         service.provider.iam.allow(
-            sid, ["execute-api:Invoke"], [arn],
+            sid,
+            ["execute-api:Invoke"],
+            [arn],
         )

--- a/serverless/aws/provider.py
+++ b/serverless/aws/provider.py
@@ -188,7 +188,7 @@ class Provider(BaseProvider, yaml.YAMLObject):
     def to_yaml(cls, dumper, data):
         data.pop("_service", None)
         data.pop("function_builder", None)
-        if not data["deploymentBucket"]:
+        if not data.get("deploymentBucket"):
             data.pop("deploymentBucket", None)
 
         return dumper.represent_dict(data)

--- a/serverless/aws/provider.py
+++ b/serverless/aws/provider.py
@@ -157,7 +157,7 @@ class Provider(BaseProvider, yaml.YAMLObject):
     yaml_tag = "!Provider"
 
     def __init__(
-        self, runtime=Runtime.PYTHON_3_8, extra_tags=None, timeout=10, stage="${opt:stage}", environment=None, **kwargs
+        self, runtime=Runtime.PYTHON_3_8, extra_tags=None, timeout=10, stage="${sls:stage}", environment=None, **kwargs
     ):
         super().__init__(**kwargs)
         self.deploymentBucket = None
@@ -166,7 +166,7 @@ class Provider(BaseProvider, yaml.YAMLObject):
 
         self.name = "aws"
         self.runtime = runtime
-        self.stackName = "${self:service}"
+        self.stackName = "${self:service}-${sls:stage}"
         self.timeout = timeout
         self.stage = stage
         self.tags = extra_tags or {}

--- a/serverless/aws/resources/dynamodb.py
+++ b/serverless/aws/resources/dynamodb.py
@@ -6,7 +6,10 @@ from serverless.aws.iam.dynamodb import DynamoDBFullAccess, DynamoDBReader, Dyna
 
 class Table(Resource):
     def __init__(self, TableName, **kwargs):
-        self.table = DynamoDBTable(title=TableName, TableName=TableName, **kwargs)
+        if "${sls:stage}" not in TableName:
+            TableName += "-${sls:stage}"
+
+        self.table = DynamoDBTable(title=TableName.replace("${sls:stage}", "").strip("-"), TableName=TableName, **kwargs)
         self.access = None
 
     def with_full_access(self):
@@ -23,6 +26,10 @@ class Table(Resource):
         self.access = DynamoDBWriter(self.table)
 
         return self
+
+    @property
+    def table_arn(self):
+        return self.table.Ref().to_dict()
 
     def resources(self):
         return [self.table]

--- a/serverless/aws/resources/dynamodb.py
+++ b/serverless/aws/resources/dynamodb.py
@@ -9,7 +9,9 @@ class Table(Resource):
         if "${sls:stage}" not in TableName:
             TableName += "-${sls:stage}"
 
-        self.table = DynamoDBTable(title=TableName.replace("${sls:stage}", "").strip("-"), TableName=TableName, **kwargs)
+        self.table = DynamoDBTable(
+            title=TableName.replace("${sls:stage}", "").strip("-"), TableName=TableName, **kwargs
+        )
         self.access = None
 
     def with_full_access(self):

--- a/serverless/service/__init__.py
+++ b/serverless/service/__init__.py
@@ -68,7 +68,7 @@ class Service(OrderedDict, yaml.YAMLObject):
         self.resources = ResourceManager(self, description)
 
         self.builder = Builder(self)
-        self.stepFunctions = StepFunctions()
+        self.stepFunctions = StepFunctions(self)
 
     def __setattr__(self, key, value):
         self[key] = value

--- a/serverless/service/__init__.py
+++ b/serverless/service/__init__.py
@@ -5,6 +5,7 @@ from typing import Optional, Union
 
 import yaml
 
+from serverless.aws.features.stepfunctions import StepFunctions
 from serverless.service.configuration import Configuration
 from serverless.service.functions import FunctionManager
 from serverless.service.package import Package
@@ -67,6 +68,7 @@ class Service(OrderedDict, yaml.YAMLObject):
         self.resources = ResourceManager(self, description)
 
         self.builder = Builder(self)
+        self.stepFunctions = StepFunctions()
 
     def __setattr__(self, key, value):
         self[key] = value

--- a/serverless/service/plugins/composed_vars.py
+++ b/serverless/service/plugins/composed_vars.py
@@ -2,7 +2,7 @@ from serverless.service.plugins.generic import Generic
 
 
 class ComposedVars(Generic):
-    yaml_tag = u"!ComposedVarsPlugin"
+    yaml_tag = "!ComposedVarsPlugin"
 
     def __init__(self):
         super().__init__("serverless-plugin-composed-vars")

--- a/serverless/service/plugins/deployment_bucket.py
+++ b/serverless/service/plugins/deployment_bucket.py
@@ -16,7 +16,7 @@ class DeploymentBucket(Generic):
     ```
     """
 
-    yaml_tag = u"!DeploymentBucketPlugin"
+    yaml_tag = "!DeploymentBucketPlugin"
 
     def __init__(
         self,

--- a/serverless/service/plugins/prune.py
+++ b/serverless/service/plugins/prune.py
@@ -2,7 +2,7 @@ from serverless.service.plugins.generic import Generic
 
 
 class Prune(Generic):
-    yaml_tag = u"!PrunePlugin"
+    yaml_tag = "!PrunePlugin"
 
     def __init__(self, automatic=True, number=3):
         super().__init__("serverless-prune-plugin")

--- a/serverless/service/plugins/step_functions.py
+++ b/serverless/service/plugins/step_functions.py
@@ -2,7 +2,7 @@ from serverless.service.plugins.generic import Generic
 
 
 class StepFunctions(Generic):
-    yaml_tag = u"!StepFunctionsPlugin"
+    yaml_tag = "!StepFunctionsPlugin"
 
     def __init__(self):
         super().__init__("serverless-step-functions")


### PR DESCRIPTION
Basic implementation of the StateMachine with AWS step functions.

This implementation currently supports: 
- Task steps 
- Map step
- Automatic configuration of the `StartAt` and `Catch` statement for all steps.
- Automatic chaining of the steps 

Sample usage:

```
machine = service.stepFunctions.machine("StreakReset", "Resetting user streaks")
task = machine.task(daily_streak_reset_find_users)
task.next(
    machine.map(
        "ProcessUsersMap", steps=[Task(daily_streak_reset_process_user, end=True)], end=True, items_path="$.userIdList"
    )
)
machine.event(Scheduled("cron(0 0 * * ? *)"))
```