### PR TITLE
Small fixes

### DIFF
--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -102,7 +102,7 @@ class Function(YamlOrderedDict):
         if use_async_dlq:
             self.use_async_dlq()
 
-        log_group = dict(Properties=dict(RetentionInDays=30))
+        log_group = dict(Type="AWS::Logs::LogGroup", Properties=dict(RetentionInDays=30))
         if service.has(Encryption):
             log_group["Properties"]["KmsKeyId"] = EncryptableResource.encryption_arn()
             log_group["DependsOn"] = [EncryptableResource.encryption_key_name() + "Alias"]

--- a/serverless/aws/iam/__init__.py
+++ b/serverless/aws/iam/__init__.py
@@ -21,7 +21,7 @@ class PolicyBuilder(YamlOrderedDict):
         self.statements.append(policy)
 
     def allow(self, permissions, resources, sid=None):
-        sid = sid or "Policy-" + str(hashlib.sha224(json.dumps([permissions, resources]).encode("ascii")).hexdigest())
+        sid = sid or "Policy" + str(hashlib.sha224(json.dumps([permissions, resources]).encode("ascii")).hexdigest())
         self.append(dict(Sid=sid, Effect="Allow", Action=permissions, Resource=resources))
 
     def deny(self, permissions, resources, sid=None):

--- a/serverless/aws/iam/__init__.py
+++ b/serverless/aws/iam/__init__.py
@@ -25,7 +25,7 @@ class PolicyBuilder(YamlOrderedDict):
         self.append(dict(Sid=sid, Effect="Allow", Action=permissions, Resource=resources))
 
     def deny(self, permissions, resources, sid=None):
-        sid = sid or "Policy-" + str(hashlib.sha224(json.dumps([permissions, resources]).encode("ascii")).hexdigest())
+        sid = sid or "Policy" + str(hashlib.sha224(json.dumps([permissions, resources]).encode("ascii")).hexdigest())
         self.append(dict(Sid=sid, Effect="Deny", Action=permissions, Resource=resources))
 
     def apply(self, preset: "IAMPreset"):

--- a/serverless/aws/iam/dynamodb.py
+++ b/serverless/aws/iam/dynamodb.py
@@ -45,7 +45,7 @@ class DynamoDBWriteOnly(IAMPreset):
                 "dynamodb:PutItem",
             ],
             resources=[self.resource.get_att("Arn").to_dict()],
-            sid=sid or self.resource.name + "Writer",
+            sid=sid or self.resource.name + "WriteOnly",
         )
 
 
@@ -56,7 +56,7 @@ class DynamoDBDelete(IAMPreset):
                 "dynamodb:DeleteItem",
             ],
             resources=[self.resource.get_att("Arn").to_dict()],
-            sid=sid or self.resource.name + "Writer",
+            sid=sid or self.resource.name + "Delete",
         )
 
 

--- a/serverless/aws/resources/dynamodb.py
+++ b/serverless/aws/resources/dynamodb.py
@@ -39,7 +39,7 @@ class Table(Resource):
     def configure(self, service):
         if service.has(Encryption):
             self.resource.SSESpecification = SSESpecification(
-                KMSMasterKeyId=self.encryption_key(), SSEEnabled=True, SSEType="KMS"
+                KMSMasterKeyId=EncryptableResource.encryption_key(), SSEEnabled=True, SSEType="KMS"
             )
 
         if service.service.pascal not in self.resource.TableName:


### PR DESCRIPTION
Fixes:
- Type is mandatory for CloudFormation resources (I'm not sure what's the intention with the DummyResource, so my solution is probably not the best.)
- Sid can only contain alphanumeric characters, so `-` is not allowed.
- Some DynamoDB SIDs had the same name