### PR TITLE
Fix idempotency table

### DIFF
--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -247,7 +247,7 @@ class Function(YamlOrderedDict):
             TimeToLiveSpecification=TimeToLiveSpecification(AttributeName="expiration", Enabled=True),
         )
         self._service.resources.add(idempotency_table)
-        self.iam.apply(DynamoDBFullAccess(idempotency_table.table))
+        self.iam.apply(DynamoDBFullAccess(idempotency_table.resource))
         env = self.get("environment", Environment())
         env.envs["IDEMPOTENCY_TABLE"] = idempotency_table.table_arn
         self.environment = env

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -245,9 +245,8 @@ class Function(YamlOrderedDict):
                 KeySchema(AttributeName="id", KeyType="HASH"),
             ],
             TimeToLiveSpecification=TimeToLiveSpecification(AttributeName="expiration", Enabled=True),
-        )
+        ).with_full_access()
         self._service.resources.add(idempotency_table)
-        self.iam.apply(DynamoDBFullAccess(idempotency_table.resource))
         env = self.get("environment", Environment())
         env.envs["IDEMPOTENCY_TABLE"] = idempotency_table.table_arn
         self.environment = env

--- a/serverless/aws/resources/dynamodb.py
+++ b/serverless/aws/resources/dynamodb.py
@@ -78,7 +78,7 @@ class Table(Resource):
     def variables(self):
         return {
             "TABLE_"
-            + Identifier(self.resource.TableName.replace("-${sls:stage}", "")).snake.upper(): self.resource.TableName
+            + Identifier(self.resource.TableName.replace("-${sls:stage}", "").replace("${sls:stage}", "")).snake.upper(): self.resource.TableName
         }
 
     def resources(self):


### PR DESCRIPTION
Fix 1:
I got this error:
```
File "serverless/aws/functions/generic.py", line 250, in with_idempotency
    self.iam.apply(DynamoDBFullAccess(idempotency_table.table))
AttributeError: 'Table' object has no attribute 'table'
```

Fix2:
Table names cannot contain `-`s and this is certainly the case with idempotency tables, so we need to replace the string`${sls:stage}` as well, without a dash. (Otherwise env vars get ugly)