### PR TITLE
Fix SID generator for EventBridge

### DIFF
--- a/serverless/aws/iam/event_bridge.py
+++ b/serverless/aws/iam/event_bridge.py
@@ -13,5 +13,5 @@ class Publish(IAMPreset):
         policy_builder.allow(
             permissions=["events:PutEvents"],
             resources=[self.event_bus],
-            sid=sid or "EventBridgePublisher" + Identifier(self.event_bus, safe=True).pascal,
+            sid=sid or "EventBridgePublisher" + Identifier(self.event_bus, safe=True).pascal.replace("_", ""),
         )


### PR DESCRIPTION
The genearated SID contains a `_` character because it's based on the ARN, but SID can only contain alphanumeric characters. Removing `_`s should resolve the issue.