### PR TITLE
Change the way we generate AWS Role name

### DIFF
--- a/serverless/service/types.py
+++ b/serverless/service/types.py
@@ -1,4 +1,5 @@
 import abc
+import hashlib
 import re
 from collections import OrderedDict
 
@@ -95,9 +96,13 @@ class ResourceName:
                     parts.append(part)
                 else:
                     parts.append(part[0:3])
-            return "-".join(parts)
+            name = "-".join(parts)
         else:
-            return self.name
+            name = self.name
+
+        name = name + "-" + hashlib.md5(safe.encode('utf-8')).hexdigest()[:5]
+
+        return name
 
 
 class ProviderMetadata(type(YamlOrderedDict), type(abc.ABC)):


### PR DESCRIPTION
**Info**
`ResourceName` is being used only by IAM at the moment

**Problem**
Function `ResourceName.__str__` produces same role names for similar string passed.
E.g.
```python
service = Service("service-name", "Description of my service", AWSProvider())
print(ResourceName("abcsomething-${sls:stage}-${aws:region}-abcsomethingandverylongsomerule-lambda", service))
print(ResourceName("abcsomething-${sls:stage}-${aws:region}-abcsomethingandverylongsomerulebutverydifferent-lambda", service))

# abc-${sls:stage}-${aws:region}-abc-lambda
# abc-${sls:stage}-${aws:region}-abc-lambda
```

**Solution**
Add hashing postfix that will be determenistic and much less likely to colide with other resources, but at this same time short.

```python
service = Service("service-name", "Description of my service", AWSProvider())
print(ResourceName("abcsomething-${sls:stage}-${aws:region}-abcsomethingandverylongsomerule-lambda", service))
print(ResourceName("abcsomething-${sls:stage}-${aws:region}-abcsomethingandverylongsomerulebutverydifferent-lambda", service))

# abc-${sls:stage}-${aws:region}-abc-lambda-cf1a3
# abc-${sls:stage}-${aws:region}-abc-lambda-951cd
```

**Breaking changes**
All roles for lambdas will change their name