### PR TITLE
Add support for Dynamodb Global Tables

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -21,6 +21,38 @@ tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)"
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
 
 [[package]]
+name = "boto3"
+version = "1.23.3"
+description = "The AWS SDK for Python"
+category = "dev"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+botocore = ">=1.26.3,<1.27.0"
+jmespath = ">=0.7.1,<2.0.0"
+s3transfer = ">=0.5.0,<0.6.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
+
+[[package]]
+name = "botocore"
+version = "1.26.3"
+description = "Low-level, data-driven core of boto 3."
+category = "dev"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+jmespath = ">=0.7.1,<2.0.0"
+python-dateutil = ">=2.1,<3.0.0"
+urllib3 = ">=1.25.4,<1.27"
+
+[package.extras]
+crt = ["awscrt (==0.13.8)"]
+
+[[package]]
 name = "bump2version"
 version = "1.0.1"
 description = "Version-bump your software with a single command!"
@@ -43,11 +75,11 @@ six = "*"
 
 [[package]]
 name = "click"
-version = "8.0.4"
+version = "8.1.3"
 description = "Composable command line interface toolkit"
 category = "main"
 optional = false
-python-versions = ">=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 colorama = {version = "*", markers = "platform_system == \"Windows\""}
@@ -75,6 +107,29 @@ description = "iniconfig: brain-dead simple config-ini parsing"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "jmespath"
+version = "1.0.0"
+description = "JSON Matching Expressions"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[[package]]
+name = "loguru"
+version = "0.6.0"
+description = "Python logging made (stupidly) simple"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
+win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+dev = ["colorama (>=0.3.4)", "docutils (==0.16)", "flake8 (>=3.7.7)", "tox (>=3.9.0)", "pytest (>=4.6.2)", "pytest-cov (>=2.7.1)", "black (>=19.10b0)", "isort (>=5.1.1)", "Sphinx (>=4.1.1)", "sphinx-autobuild (>=0.7.1)", "sphinx-rtd-theme (>=0.4.3)"]
 
 [[package]]
 name = "packaging"
@@ -140,12 +195,37 @@ tomli = ">=1.0.0"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "pygments (>=2.7.2)", "requests", "xmlschema"]
 
 [[package]]
+name = "python-dateutil"
+version = "2.8.2"
+description = "Extensions to the standard Python datetime module"
+category = "dev"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
+
+[package.dependencies]
+six = ">=1.5"
+
+[[package]]
 name = "pyyaml"
 version = "6.0"
 description = "YAML parser and emitter for Python"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "s3transfer"
+version = "0.5.2"
+description = "An Amazon S3 Transfer Manager"
+category = "dev"
+optional = false
+python-versions = ">= 3.6"
+
+[package.dependencies]
+botocore = ">=1.12.36,<2.0a.0"
+
+[package.extras]
+crt = ["botocore[crt] (>=1.20.29,<2.0a.0)"]
 
 [[package]]
 name = "six"
@@ -177,10 +257,34 @@ cfn-flip = ">=1.0.2"
 [package.extras]
 policy = ["awacs (>=2.0.0)"]
 
+[[package]]
+name = "urllib3"
+version = "1.26.9"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+
+[package.extras]
+brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
+secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
+
+[[package]]
+name = "win32-setctime"
+version = "1.1.0"
+description = "A small Python utility to set file creation time on Windows"
+category = "dev"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["pytest (>=4.6.2)", "black (>=19.3b0)"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c4a7d2a825c76b8ce510f8919f41aeafa783a3bda9b4ead3eba2c62700146a29"
+content-hash = "5b328260f70b4ba8e177fa7ca947a31f7022b2668074c32a01284ea7886fd5ed"
 
 [metadata.files]
 atomicwrites = [
@@ -191,6 +295,14 @@ attrs = [
     {file = "attrs-21.4.0-py2.py3-none-any.whl", hash = "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4"},
     {file = "attrs-21.4.0.tar.gz", hash = "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"},
 ]
+boto3 = [
+    {file = "boto3-1.23.3-py3-none-any.whl", hash = "sha256:5f27eec9b0a43edbfb3ed5e748837b10219a972f0728fecd78f84ec3629f2092"},
+    {file = "boto3-1.23.3.tar.gz", hash = "sha256:9d5ce5ae3ddd4429cf752efe7c9f39691db6c85b6b5f1cfc8861b8f23b72b67a"},
+]
+botocore = [
+    {file = "botocore-1.26.3-py3-none-any.whl", hash = "sha256:869308e29c1e8a9baa3e2fc336a1293e098855e34ea77c035dc4194a96316688"},
+    {file = "botocore-1.26.3.tar.gz", hash = "sha256:f83c5cd7b3e1889aabf2fcf7926ddafc41f249a29f76f37cdb9e8680ac9b5af4"},
+]
 bump2version = [
     {file = "bump2version-1.0.1-py2.py3-none-any.whl", hash = "sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410"},
     {file = "bump2version-1.0.1.tar.gz", hash = "sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6"},
@@ -200,8 +312,8 @@ cfn-flip = [
     {file = "cfn_flip-1.3.0.tar.gz", hash = "sha256:003e02a089c35e1230ffd0e1bcfbbc4b12cc7d2deb2fcc6c4228ac9819307362"},
 ]
 click = [
-    {file = "click-8.0.4-py3-none-any.whl", hash = "sha256:6a7a62563bbfabfda3a38f3023a1db4a35978c0abd76f6c9605ecd6554d6d9b1"},
-    {file = "click-8.0.4.tar.gz", hash = "sha256:8458d7b1287c5fb128c90e23381cf99dcde74beaf6c7ff6384ce84d6fe090adb"},
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
 ]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
@@ -214,6 +326,14 @@ inflection = [
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+jmespath = [
+    {file = "jmespath-1.0.0-py3-none-any.whl", hash = "sha256:e8dcd576ed616f14ec02eed0005c85973b5890083313860136657e24784e4c04"},
+    {file = "jmespath-1.0.0.tar.gz", hash = "sha256:a490e280edd1f57d6de88636992d05b71e97d69a26a19f058ecf7d304474bf5e"},
+]
+loguru = [
+    {file = "loguru-0.6.0-py3-none-any.whl", hash = "sha256:4e2414d534a2ab57573365b3e6d0234dfb1d84b68b7f3b948e6fb743860a77c3"},
+    {file = "loguru-0.6.0.tar.gz", hash = "sha256:066bd06758d0a513e9836fd9c6b5a75bfb3fd36841f4b996bc60b547a309d41c"},
 ]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
@@ -234,6 +354,10 @@ pyparsing = [
 pytest = [
     {file = "pytest-7.1.1-py3-none-any.whl", hash = "sha256:92f723789a8fdd7180b6b06483874feca4c48a5c76968e03bb3e7f806a1869ea"},
     {file = "pytest-7.1.1.tar.gz", hash = "sha256:841132caef6b1ad17a9afde46dc4f6cfa59a05f9555aae5151f73bdf2820ca63"},
+]
+python-dateutil = [
+    {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
+    {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
 ]
 pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
@@ -270,6 +394,10 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
+s3transfer = [
+    {file = "s3transfer-0.5.2-py3-none-any.whl", hash = "sha256:7a6f4c4d1fdb9a2b640244008e142cbc2cd3ae34b386584ef044dd0f27101971"},
+    {file = "s3transfer-0.5.2.tar.gz", hash = "sha256:95c58c194ce657a5f4fb0b9e60a84968c808888aed628cd98ab8771fe1db98ed"},
+]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
     {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
@@ -281,4 +409,12 @@ tomli = [
 troposphere = [
     {file = "troposphere-3.2.2-py3-none-any.whl", hash = "sha256:e802b1e67eecd24f7e4762b0f4e1609568e87beecb791a85930376423404823b"},
     {file = "troposphere-3.2.2.tar.gz", hash = "sha256:9d07338ed882928db9de9795beb8ee553e9618db20d782237ee4e4f52dfb52b2"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
+    {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
+]
+win32-setctime = [
+    {file = "win32_setctime-1.1.0-py3-none-any.whl", hash = "sha256:231db239e959c2fe7eb1d7dc129f11172354f98361c4fa2d6d2d7e278baa8aad"},
+    {file = "win32_setctime-1.1.0.tar.gz", hash = "sha256:15cf5750465118d6929ae4de4eb46e8edae9a5634350c01ba582df868e932cb2"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,12 @@ inflection = "^0.5.1"
 [tool.poetry.dev-dependencies]
 pytest = "^7.0"
 bump2version = "^1.0.1"
+click = "^8.1.3"
+boto3 = "^1.23.3"
+loguru = "^0.6.0"
+
+[tool.poetry.scripts]
+slscli = "serverless.cli:cli"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/serverless/aws/features/encryption.py
+++ b/serverless/aws/features/encryption.py
@@ -1,6 +1,7 @@
 from troposphere.kms import Alias, Key
 
 from serverless.service.plugins.kms import KMSGrant
+from serverless.service.plugins.scriptable import Scriptable
 from serverless.service.types import Feature
 
 
@@ -53,7 +54,12 @@ class Encryption(Feature):
     def pre_render(self, service):
         super().pre_render(service)
 
-        if not service.regions:
+        if service.regions:
+            if not service.plugins.has(Scriptable):
+                service.plugins.add(Scriptable())
+
+            # service.plugins.get(Scriptable).hooks.append("")
+
             return
 
         for fn in service.functions.all():

--- a/serverless/aws/functions/dynamodb.py
+++ b/serverless/aws/functions/dynamodb.py
@@ -1,0 +1,62 @@
+from serverless.aws.functions.generic import Function
+from serverless.service.types import YamlOrderedDict
+
+
+class DynamoDBStreamEvent(YamlOrderedDict):
+    yaml_tag = "stream"
+
+    def __init__(
+        self,
+        arn,
+        batchSize=10,
+        maximumRecordAgeInSeconds=120,
+        maximumRetryAttempts=5,
+        startingPosition="LATEST",
+        destinations=None,
+    ):
+        super().__init__()
+        self.arn = arn
+        self.batchSize = batchSize
+        self.maximumRecordAgeInSeconds = maximumRecordAgeInSeconds
+        self.maximumRetryAttempts = maximumRetryAttempts
+        self.startingPosition = startingPosition
+        self.type="dynamodb"
+
+        if destinations:
+            self.destinations = destinations
+
+
+class DynamoDBStreamFunction(Function):
+    yaml_tag = "!DynamoDBStreamFunction"
+
+    def __init__(
+        self,
+        stream,
+        service,
+        name,
+        description,
+        handler=None,
+        timeout=None,
+        layers=None,
+        batch_size=10,
+        maximum_record_age_in_seconds=120,
+        maximum_retry_attempts=5,
+        starting_position="LATEST",
+        destinations=None,
+        use_dlq=True,
+        use_async_dlq=True,
+        **kwargs,
+    ):
+        super().__init__(
+            service, name, description, handler, timeout, layers, use_dlq=use_dlq, use_async_dlq=use_async_dlq, **kwargs
+        )
+        self.trigger(
+            DynamoDBStreamEvent(
+                arn=stream,
+                batchSize=batch_size,
+                maximumRecordAgeInSeconds=maximum_record_age_in_seconds,
+                maximumRetryAttempts=maximum_retry_attempts,
+                startingPosition=starting_position,
+                destinations=destinations,
+            )
+        )

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -77,6 +77,8 @@ class Function(YamlOrderedDict):
 
             layers.append({"Ref": "PythonRequirementsLambdaLayer"})
 
+        self._service.resources.output(self.name.spinal + "-arn", self.arn())
+
         if layers:
             self.layers = layers
 
@@ -207,17 +209,11 @@ class Function(YamlOrderedDict):
             )
         )
 
-        self._service.resources.add(
-            DummyResource(
-                self.resource_name(),
-                Type="AWS::Lambda::Function",
-                DependsOn=[
-                    self.iam_role_name(),
-                    self.log_group_name(),
-                    resource,
-                ],
-            )
-        )
+        self.dependsOn = [
+            self.iam_role_name(),
+            self.log_group_name(),
+            resource,
+        ]
 
         return {"Ref": f"{self.name.pascal}DLQ", "arn": SQSArn(name)}
 

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -100,7 +100,8 @@ class Function(YamlOrderedDict):
         log_group = dict(Type="AWS::Logs::LogGroup", Properties=dict(RetentionInDays=30))
         if service.has(Encryption):
             log_group["Properties"]["KmsKeyId"] = EncryptableResource.encryption_arn()
-            log_group["DependsOn"] = [EncryptableResource.encryption_key_name() + "Alias"]
+            if not service.regions:
+                log_group["DependsOn"] = [EncryptableResource.encryption_key_name() + "Alias"]
 
         service.resources.add(DummyResource(title=self.log_group_name(), **log_group))
 

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -77,7 +77,7 @@ class Function(YamlOrderedDict):
 
             layers.append({"Ref": "PythonRequirementsLambdaLayer"})
 
-        self._service.resources.export(self.resource_name() + "ArnOutput",  self.name.spinal + "-arn", self.arn())
+        self._service.resources.export(self.resource_name() + "ArnOutput",  self.name.spinal + "-arn", self.arn(), append=False)
 
         if layers:
             self.layers = layers

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -77,7 +77,7 @@ class Function(YamlOrderedDict):
 
             layers.append({"Ref": "PythonRequirementsLambdaLayer"})
 
-        self._service.resources.output(self.name.spinal + "-arn", self.arn())
+        self._service.resources.export(self.resource_name() + "ArnOutput",  self.name.spinal + "-arn", self.arn())
 
         if layers:
             self.layers = layers

--- a/serverless/aws/iam/dynamodb.py
+++ b/serverless/aws/iam/dynamodb.py
@@ -1,7 +1,7 @@
-from troposphere import Join
 from troposphere.dynamodb import Table
 
 from serverless.aws.iam import IAMPreset, PolicyBuilder
+from serverless.aws.types import DynamoDBArn, DynamoDBIndexArn
 
 
 class DynamoDBReader(IAMPreset):
@@ -15,8 +15,8 @@ class DynamoDBReader(IAMPreset):
                 "dynamodb:Scan",
             ],
             resources=[
-                self.resource.get_att("Arn").to_dict(),
-                Join(delimiter="", values=[self.resource.get_att("Arn").to_dict(), "/index/*"]).to_dict(),
+                DynamoDBArn(self.resource),
+                DynamoDBIndexArn(self.resource, "*")
             ],
             sid=sid or self.resource.name + "Reader",
         )
@@ -31,7 +31,7 @@ class DynamoDBWriter(IAMPreset):
                 "dynamodb:UpdateItem",
                 "dynamodb:PutItem",
             ],
-            resources=[self.resource.get_att("Arn").to_dict()],
+            resources=[DynamoDBArn(self.resource)],
             sid=sid or self.resource.name + "Writer",
         )
 
@@ -44,7 +44,7 @@ class DynamoDBWriteOnly(IAMPreset):
                 "dynamodb:UpdateItem",
                 "dynamodb:PutItem",
             ],
-            resources=[self.resource.get_att("Arn").to_dict()],
+            resources=[DynamoDBArn(self.resource)],
             sid=sid or self.resource.name + "WriteOnly",
         )
 
@@ -55,7 +55,7 @@ class DynamoDBDelete(IAMPreset):
             permissions=[
                 "dynamodb:DeleteItem",
             ],
-            resources=[self.resource.get_att("Arn").to_dict()],
+            resources=[DynamoDBArn(self.resource)],
             sid=sid or self.resource.name + "Delete",
         )
 
@@ -72,6 +72,6 @@ class DynamoDBFullAccess(IAMPreset):
                 "dynamodb:UpdateItem",
                 "dynamodb:PutItem",
             ],
-            resources=[self.resource.get_att("Arn").to_dict()],
+            resources=[DynamoDBArn(self.resource)],
             sid=sid or self.resource.name + "FullAccess",
         )

--- a/serverless/aws/provider.py
+++ b/serverless/aws/provider.py
@@ -1,5 +1,6 @@
 import yaml
 
+from serverless.aws.functions.dynamodb import DynamoDBStreamFunction
 from serverless.aws.functions.event_bridge import EventBridgeFunction
 from serverless.aws.functions.generic import Function
 from serverless.aws.functions.http import HTTPFunction
@@ -157,6 +158,12 @@ class FunctionBuilder:
 
     def kinesis(self, stream, name, description, **kwargs):
         fn = KinesisFunction(stream, self.service, name, description, **kwargs)
+        self.service.functions.add(fn)
+
+        return fn
+
+    def dynamodb_stream(self, stream, name, description, **kwargs):
+        fn = DynamoDBStreamFunction(stream, self.service, name, description, **kwargs)
         self.service.functions.add(fn)
 
         return fn

--- a/serverless/aws/resources/logs.py
+++ b/serverless/aws/resources/logs.py
@@ -21,7 +21,7 @@ class LogGroup(Resource):
         if service.has(Encryption):
             self.resource.KmsKeyId = EncryptableResource.encryption_arn()
 
-            # if not service.regions:
-            #     self.resource.DependsOn = [EncryptableResource.encryption_key_name() + "Alias"]
+            if not service.regions:
+                self.resource.DependsOn = [EncryptableResource.encryption_key_name() + "Alias"]
 
         super().configure(service)

--- a/serverless/aws/resources/logs.py
+++ b/serverless/aws/resources/logs.py
@@ -20,6 +20,8 @@ class LogGroup(Resource):
 
         if service.has(Encryption):
             self.resource.KmsKeyId = EncryptableResource.encryption_arn()
-            self.resource.DependsOn = [EncryptableResource.encryption_key_name() + "Alias"]
+
+            # if not service.regions:
+            #     self.resource.DependsOn = [EncryptableResource.encryption_key_name() + "Alias"]
 
         super().configure(service)

--- a/serverless/aws/resources/sqs.py
+++ b/serverless/aws/resources/sqs.py
@@ -19,7 +19,7 @@ class Queue(Resource):
         super().configure(service)
 
         if service.has(Encryption):
-            self.resource.KmsMasterKeyId = EncryptableResource.encryption_key()
+            self.resource.KmsMasterKeyId = EncryptableResource.encryption_alias()
 
     def permissions(self):
         return []

--- a/serverless/aws/types.py
+++ b/serverless/aws/types.py
@@ -1,3 +1,5 @@
+import yaml
+
 from serverless.service import YamlOrderedDict
 
 
@@ -17,6 +19,27 @@ class SQSArn(GenericArn):
         return f"arn:aws:sqs:${{aws:region}}:${{aws:accountId}}:{self.name}"
 
 
+class DynamoDBArn(GenericArn):
+    yaml_tag = "!Arn"
+
+    def __init__(self, table):
+        self.table = table
+
+    def __str__(self):
+        return f"arn:aws:dynamodb:${{aws:region}}:${{aws:accountId}}:table/{self.table.TableName}"
+
+
+class DynamoDBIndexArn(GenericArn):
+    yaml_tag = "!Arn"
+
+    def __init__(self, table, index="*"):
+        self.table = table
+        self.index = index
+
+    def __str__(self):
+        return f"arn:aws:dynamodb:${{aws:region}}:${{aws:accountId}}:table/{self.table.TableName}/index/{self.index}"
+
+
 class EventBridgeBusArn(GenericArn):
     yaml_tag = "!Arn"
 
@@ -25,3 +48,26 @@ class EventBridgeBusArn(GenericArn):
 
     def __str__(self):
         return f"arn:aws:events:${{aws:region}}:${{aws:accountId}}:event-bus/{self.name}"
+
+
+class Ref(yaml.YAMLObject):
+    yaml_tag = "!Ref"
+
+    def __init__(self, data):
+        self.data = data
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_dict({"Ref": data.data})
+
+
+class Equals(yaml.YAMLObject):
+    yaml_tag = "!Equals"
+
+    def __init__(self, title, data):
+        self.title = title
+        self.data = data
+
+    @classmethod
+    def to_yaml(cls, dumper, data):
+        return dumper.represent_dict({"Fn::Equals": data.data})

--- a/serverless/cli.py
+++ b/serverless/cli.py
@@ -1,0 +1,166 @@
+import json
+from os import getcwd
+from os.path import join, isfile
+
+import boto3
+import click
+import yaml
+from loguru import logger
+
+from serverless.aws.features.encryption import Encryption
+
+
+@click.group()
+def cli():
+    pass
+
+
+@cli.group()
+def kms():
+    pass
+
+
+def retrieve_key(service):
+    kms_client = boto3.client("kms")
+    response = kms_client.list_keys(Limit=1000)
+
+    for cmk in response["Keys"]:
+        try:
+            tags = kms_client.list_resource_tags(KeyId=cmk["KeyArn"])
+            if (next(filter(lambda x: x["TagKey"] == "SERVICE", tags["Tags"]), {})).get("TagValue") == service:
+                metadata = kms_client.describe_key(KeyId=cmk["KeyId"]).get("KeyMetadata")
+                if not all([metadata.get("Enabled"), metadata.get("KeyState") == "Enabled"]):
+                    continue
+
+                return cmk["KeyId"], cmk["KeyArn"]
+        except Exception as e:
+            print(e)
+
+    return None, None
+
+
+def replace_variables(variables, string):
+    for word, initial in variables.items():
+        string = string.replace(word, initial)
+
+    return string
+
+
+@kms.command(name="create")
+@click.argument("service")
+@click.option("-p", "--path", default=join(getcwd(), "serverless.yml"), type=click.Path())
+@click.option('-s', '--stage', required=True)
+@click.option('-r', '--region', multiple=True)
+def kms_create(service, region, stage, path):
+    client = boto3.client('kms')
+
+    variables = {
+        "${aws:accountId}": boto3.client('sts').get_caller_identity().get('Account'),
+        "${aws:region}": client.meta.region_name,
+        "${self:service}": service,
+        "${sls:stage}": stage
+    }
+
+    POLICY_TEMPLATE = Encryption.POLICY
+    if isfile(path):
+        with open(path, "r") as f:
+            definition = yaml.load(f, Loader=yaml.Loader)
+            for fn in definition.get("functions").values():
+                POLICY_TEMPLATE["Statement"].append({
+                    "Effect": "Allow",
+                    "Principal": {"Service": "logs.${aws:region}.amazonaws.com"},
+                    "Action": [
+                        "kms:Encrypt*",
+                        "kms:Decrypt*",
+                        "kms:ReEncrypt*",
+                        "kms:GenerateDataKey*",
+                        "kms:Describe*",
+                    ],
+                    "Resource": "*",
+                    "Condition": {
+                        "ArnLike": {
+                            "kms:EncryptionContext:aws:logs:arn": "arn:aws:logs:${aws:region}:${aws:accountId}:log-group:/aws/lambda/"
+                                                                  + fn.get("name")
+                        }
+                    },
+                })
+
+    POLICY_TEMPLATE = json.dumps(POLICY_TEMPLATE)
+
+    defaults = dict(
+        Description=f"Encryption Key for {service}",
+        Tags=[
+            {
+                'TagKey': 'SERVICE',
+                'TagValue': service
+            },
+        ],
+    )
+
+    logger.info(f"Creating multi-region KMS key for {service} in {region}")
+
+    key_id, key_arn = retrieve_key(service)
+    if not key_id:
+        logger.info("Master key not found. Creating a new one.")
+        response = client.create_key(
+            Policy=replace_variables(variables, POLICY_TEMPLATE),
+            MultiRegion=True,
+            **defaults
+        )
+
+        key_id = response.get("KeyMetadata").get("KeyId")
+        key_arn = response.get("KeyMetadata").get("Arn")
+    else:
+        logger.info("Update key policy")
+        client.put_key_policy(
+            KeyId=key_id,
+            PolicyName="default",
+            Policy=replace_variables(variables, POLICY_TEMPLATE)
+        )
+
+    logger.info(f"Using key: {key_id}")
+
+    try:
+        alias = f'alias/{service}-{stage}'
+        client.create_alias(
+            AliasName=alias,
+            TargetKeyId=key_id,
+        )
+        logger.info(f"Created an alias: {alias}")
+    except client.exceptions.AlreadyExistsException:
+        logger.info(f"Using existing alias: {alias}")
+        pass
+
+    for target_region in [r for r in region if r != client.meta.region_name]:
+        logger.info(f"Replicating key to: {target_region}")
+        variables["${aws:region}"] = target_region
+
+        target_session = boto3.client('kms', region_name=target_region)
+
+        try:
+            replica = target_session.describe_key(KeyId=key_id)
+            logger.info(f"Key replica {key_id} exists in {target_region}")
+        except target_session.exceptions.NotFoundException as e:
+            replica = client.replicate_key(
+                Policy=replace_variables(variables, POLICY_TEMPLATE),
+                KeyId=key_id,
+                ReplicaRegion=target_region,
+                **defaults
+            )
+            logger.info(f"Replicate key created in {target_region}")
+
+        logger.info(f"Update key policy in {target_region}")
+        target_session.put_key_policy(
+            KeyId=key_id,
+            PolicyName="default",
+            Policy=replace_variables(variables, POLICY_TEMPLATE)
+        )
+
+        try:
+            target_session.create_alias(
+                AliasName=f'alias/{service}-{stage}',
+                TargetKeyId=replica.get("KeyMetadata").get("KeyId"),
+            )
+            logger.info(f"Created key alias in {target_region}")
+        except client.exceptions.AlreadyExistsException:
+            logger.info(f"Using existing alias of key in {target_region}")

--- a/serverless/cli.py
+++ b/serverless/cli.py
@@ -138,7 +138,7 @@ def kms_create(service, region, stage, path):
         target_session = boto3.client('kms', region_name=target_region)
 
         try:
-            replica = target_session.describe_key(KeyId=key_id)
+            replica = target_session.describe_key(KeyId=key_id).get("KeyMetadata")
             logger.info(f"Key replica {key_id} exists in {target_region}")
         except target_session.exceptions.NotFoundException as e:
             replica = client.replicate_key(
@@ -146,7 +146,7 @@ def kms_create(service, region, stage, path):
                 KeyId=key_id,
                 ReplicaRegion=target_region,
                 **defaults
-            )
+            ).get("ReplicaKeyMetadata")
             logger.info(f"Replicate key created in {target_region}")
 
         logger.info(f"Update key policy in {target_region}")
@@ -159,7 +159,7 @@ def kms_create(service, region, stage, path):
         try:
             target_session.create_alias(
                 AliasName=f'alias/{service}-{stage}',
-                TargetKeyId=replica.get("KeyMetadata").get("KeyId"),
+                TargetKeyId=replica.get("KeyId"),
             )
             logger.info(f"Created key alias in {target_region}")
         except client.exceptions.AlreadyExistsException:

--- a/serverless/service/__init__.py
+++ b/serverless/service/__init__.py
@@ -49,6 +49,7 @@ class Service(OrderedDict, yaml.YAMLObject):
         provider: Provider,
         config: Optional[Configuration] = None,
         custom: Optional[dict] = None,
+        regions=None,
         **kwds,
     ):
         super().__init__(**kwds)
@@ -58,6 +59,7 @@ class Service(OrderedDict, yaml.YAMLObject):
         self.variablesResolutionMode = 20210326
         self.custom = YamlOrderedDict(vars="${file(./variables.yml):${sls:stage}}", **(custom or {}))
         self.config = config or Configuration()
+        self.regions = regions
 
         provider.configure(self)
         self.provider = provider
@@ -141,5 +143,6 @@ class Service(OrderedDict, yaml.YAMLObject):
             feature.pre_render(data)
 
         data.pop("features", None)
+        data.pop("regions", None)
 
         return dumper.represent_dict(data)

--- a/serverless/service/plugins/domain_manager.py
+++ b/serverless/service/plugins/domain_manager.py
@@ -8,10 +8,12 @@ class DomainManager(Generic):
 
     yaml_tag = "!DomainManagerPlugin"
 
-    def __init__(self, domain, api="rest", stage="${sls:stage}", base_path=None, create_route_53_record=False):
+    def __init__(self, domain="api", api="rest", stage="${sls:stage}", base_path="", create_route_53_record=False, **kwargs):
         super().__init__("serverless-domain-manager")
+
+        kwargs.setdefault("domainName", f"{api}.{domain}")
         self[api] = dict(
-            domainName=f"{api}.{domain}", stage=stage, basePath=base_path, createRoute53Record=create_route_53_record
+            stage=stage, basePath=base_path, createRoute53Record=create_route_53_record, **kwargs
         )
 
     def enable(self, service):

--- a/serverless/service/plugins/domain_manager.py
+++ b/serverless/service/plugins/domain_manager.py
@@ -1,4 +1,5 @@
 from serverless.service.plugins.generic import Generic
+import troposphere.ssm as ssm
 
 
 class DomainManager(Generic):
@@ -21,3 +22,8 @@ class DomainManager(Generic):
         export.pop("name", None)
 
         service.custom.customDomain = export
+        param = service.resources.parameter(
+            "RESTApiId",
+            "api-id",
+            {"Fn::GetAtt": ["ApiGatewayRestApi", "RootResourceId"]}
+        )

--- a/serverless/service/plugins/dynamodb.py
+++ b/serverless/service/plugins/dynamodb.py
@@ -1,0 +1,15 @@
+from serverless.service.plugins.generic import Generic
+
+
+class GlobalTables(Generic):
+    yaml_tag = "!DynamoTable"
+
+    def __init__(self, regions, version="2", createStack=True):
+        super().__init__("serverless-create-global-dynamodb-table")
+        self.createStack = createStack
+        self.regions = regions
+        self.version = version
+
+    def enable(self, service):
+        super().enable(service)
+        service.custom.globalTables = dict(version=self.version, regions=self.regions, createStack=self.createStack)

--- a/serverless/service/resources.py
+++ b/serverless/service/resources.py
@@ -59,7 +59,7 @@ class ResourceManager(yaml.YAMLObject):
     def parameter(self, resource_id, name, value, type="String"):
         param = self.add(ssm.Parameter(
             resource_id,
-            Name=f"/${{self:service}}/${{sls:stage}}/{name}",
+            Name=f"/services/${{self:service}}/${{sls:stage}}/{name}",
             Type=type,
             Value=""
         ))

--- a/serverless/service/resources.py
+++ b/serverless/service/resources.py
@@ -43,16 +43,18 @@ class ResourceManager(yaml.YAMLObject):
     def all(self):
         return self.resources
 
-    def output(self, output_name, name, value, export=False):
+    def output(self, output_name, name, value, append=True, export=False):
         output = {
             "Value": value
         }
         if export:
-            output["Export"] = {"Name": "${self:service}-${sls:stage}-" + name}
+            if append:
+                name = "${self:service}-${sls:stage}-" + name
+            output["Export"] = {"Name": name}
         self.outputs[output_name] = output
 
-    def export(self, output_name, name, value):
-        return self.output(output_name, name, value, export=True)
+    def export(self, output_name, name, value, append=True):
+        return self.output(output_name, name, value, append, export=True)
 
     def parameter(self, resource_id, name, value, type="String"):
         param = self.add(ssm.Parameter(

--- a/serverless/service/resources.py
+++ b/serverless/service/resources.py
@@ -43,16 +43,16 @@ class ResourceManager(yaml.YAMLObject):
     def all(self):
         return self.resources
 
-    def output(self, name, value, export=False):
+    def output(self, output_name, name, value, export=False):
         output = {
             "Value": value
         }
         if export:
-            output["Export"] = {"Name": "${sls:service}-${sls:stage}-" + name}
-        self.outputs[name] = output
+            output["Export"] = {"Name": "${self:service}-${sls:stage}-" + name}
+        self.outputs[output_name] = output
 
-    def export(self, name, value):
-        return output(name, value, export=True)
+    def export(self, output_name, name, value):
+        return self.output(output_name, name, value, export=True)
 
     def parameter(self, resource_id, name, value, type="String"):
         param = self.add(ssm.Parameter(

--- a/serverless/service/resources.py
+++ b/serverless/service/resources.py
@@ -14,6 +14,7 @@ class ResourceManager(yaml.YAMLObject):
         self.description = description
         self._service = service
         self.resources = []
+        self.conditions = []
 
     def add(self, resource: Union[AWSObject, Resource]):
         if isinstance(resource, Resource):
@@ -25,6 +26,11 @@ class ResourceManager(yaml.YAMLObject):
                 self._service.provider.iam.apply(preset)
         else:
             self.resources.append(resource)
+
+        return resource
+
+    def add_condition(self, resource: Union[AWSObject]):
+        self.conditions.append(resource)
 
         return resource
 
@@ -41,5 +47,6 @@ class ResourceManager(yaml.YAMLObject):
             dict(
                 Description=data.description,
                 Resources={resource.title: resource.to_dict() for resource in data.resources},
+                Conditions={condition.title: condition for condition in data.conditions},
             )
         )

--- a/serverless/service/resources.py
+++ b/serverless/service/resources.py
@@ -1,5 +1,6 @@
 from typing import Union
 
+import troposphere.ssm as ssm
 import yaml
 from troposphere import AWSObject
 
@@ -40,6 +41,17 @@ class ResourceManager(yaml.YAMLObject):
 
     def all(self):
         return self.resources
+
+    def parameter(self, resource_id, name, value, type="String"):
+        param = self.add(ssm.Parameter(
+            resource_id,
+            Name=f"/${{self:service}}/${{sls:stage}}/{name}",
+            Type=type,
+            Value=""
+        ))
+        param.properties.__setitem__("Value", value)
+
+        return param
 
     @classmethod
     def to_yaml(cls, dumper, data):

--- a/serverless/service/types.py
+++ b/serverless/service/types.py
@@ -89,7 +89,7 @@ class ResourceName:
         safe = safe.replace("${self:service}", self.service.service.spinal)
         safe = safe.replace("${sls:stage}", "staging")
 
-        if len(safe) > 60:
+        if len(safe) > 55:
             parts = []
             for part in self.name.split("-"):
                 if "$" in part or part == "lambda":

--- a/serverless/service/types.py
+++ b/serverless/service/types.py
@@ -62,7 +62,7 @@ class Identifier(yaml.YAMLObject):
 
     @property
     def spinal(self):
-        return inflection.dasherize(self.identifier).lower()
+        return inflection.dasherize(inflection.underscore(self.identifier)).lower()
 
     @property
     def resource(self):

--- a/serverless/service/types.py
+++ b/serverless/service/types.py
@@ -100,7 +100,7 @@ class ResourceName:
         else:
             name = self.name
 
-        name = name + "-" + hashlib.md5(safe.encode('utf-8')).hexdigest()[:5]
+        name = name + "-" + hashlib.md5(safe.encode("utf-8")).hexdigest()[:5]
 
         return name
 


### PR DESCRIPTION
## The problem
AWS provides support for GlobalTables via `AWS::DynamoDB::GlobalTable` resource, which implicates a few problems:
1. GlobalTables with defined replicas are automatically created in all regions which enforce a conditional resource in serverless.yml file 
2. Making table creation conditional enforces manual ARN creation for IAM policies and other references 
3. All our tables must have KMS encryption enabled with Customer Managed Key - that means CMK must exist in all replica environments before the first deployment 
4. We don't have support for cross region resources in CloudFormation nor Serverless framework
5. Removal of the KMS management from `serverless.yml` implicates other problems as key is used with SQS, log groups 
etc. 


## The solution

1. Create a simple tool as a part of serverless project - a CLI command which will ensure KMS key exists in all regions with same alias and is defined as multiregion key 
2. Execute tool as hook before deployment so we can be sure that keys exists 
3. Replace all KMS references with generated alias name 
4. Replace Table references with generated ARN 