### PR TITLE
IAM role name fix

### DIFF
--- a/serverless/aws/iam/__init__.py
+++ b/serverless/aws/iam/__init__.py
@@ -65,7 +65,7 @@ class ServicePolicyBuilder(PolicyBuilder):
     def to_yaml(cls, dumper, data):
         export = dict(data.items())
         export.pop("service", None)
-
+        export["name"] = data.role
         return dumper.represent_dict(dict(role=export))
 
 


### PR DESCRIPTION
Here: https://github.com/epsylabs/serverless-builder/blob/master/serverless/service/plugins/kms.py#L30 we use the role property as the role name, and https://github.com/epsylabs/serverless-builder/commit/86d2b3a406a4cec687f8e4c1fd75252ad8147f57 changed the way we generate role names, so to make references consistent we need to change it here, too.