### PR TITLE
Change `spinal` to `snake` in generation of function handler.

### DIFF
--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -56,7 +56,7 @@ class Function(YamlOrderedDict):
         self.description = description
 
         if not handler:
-            handler = f"{self._service.service.snake}.{self.key.spinal}.handler"
+            handler = f"{self._service.service.snake}.{self.key.snake}.handler"
 
         self.handler = handler
         self.events = []


### PR DESCRIPTION
In commit https://github.com/epsylabs/serverless-builder/commit/eada008b01fd9c94146bf518438f29310f7e52fa#diff-55e8807f211fb1ebd6a74aa464cdc96c99d5d3e80f7e9742a4823ef7eababfc2L66  it got changed from `snake` to `spinal`, which I believe was not intentional.

Because from name of function `AbcDef` it will create `abc-def` import name, which is wrong, correct name should be `abc_def`.

This PR reverts this change.