### PR TITLE
Remove `sqs:SendMessageBatch` IAM

### DIFF
--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -189,7 +189,7 @@ class Function(YamlOrderedDict):
 
         self.iam.allow(
             sid=f"{self.name.resource}DLQWriter",
-            permissions=["sqs:GetQueueUrl", "sqs:SendMessageBatch", "sqs:SendMessage"],
+            permissions=["sqs:GetQueueUrl", "sqs:SendMessage"],
             resources=[self.dlq.arn()],
         )
 

--- a/serverless/aws/iam/sqs.py
+++ b/serverless/aws/iam/sqs.py
@@ -10,7 +10,7 @@ class SQSPublisher(IAMPreset):
 
     def apply(self, policy_builder: PolicyBuilder, sid=None):
         policy_builder.allow(
-            permissions=["sqs:SendMessageBatch", "sqs:SendMessage"],
+            permissions=["sqs:SendMessage"],
             resources=str(self.resource),
             sid="SQSPublisherI" + hashlib.sha224(str(self.resource).encode("ascii")).hexdigest(),
         )

--- a/serverless/integration/event_dispatcher.py
+++ b/serverless/integration/event_dispatcher.py
@@ -37,7 +37,7 @@ class EventDispatcher(Integration):
         )
         service.provider.iam.allow(
             sid="EventDispatcherDLQBatch",
-            permissions=["sqs:SendMessageBatch", "sqs:GetQueueUrl"],
+            permissions=["sqs:SendMessage", "sqs:GetQueueUrl"],
             resources=[queue.arn()],
         )
 


### PR DESCRIPTION
Based on documentation in [Amazon SQS API permissions: Actions and resource reference](https://docs.amazonaws.cn/en_us/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-api-permissions-reference.html) there is no `sqs:SendMessageBatch` permission.

<img width="1191" alt="Screenshot 2022-08-13 at 21 33 56" src="https://user-images.githubusercontent.com/164009/184508209-bf57665e-7bd6-4dab-98d0-7ce6535a5725.png">

