### PR TITLE
Make sure that hash is generated correctly

### DIFF
--- a/serverless/aws/iam/__init__.py
+++ b/serverless/aws/iam/__init__.py
@@ -21,11 +21,11 @@ class PolicyBuilder(YamlOrderedDict):
         self.statements.append(policy)
 
     def allow(self, permissions, resources, sid=None):
-        sid = sid or "Policy" + str(hashlib.sha224(json.dumps([permissions, resources]).encode("ascii")).hexdigest())
+        sid = sid or "Policy" + str(hashlib.sha224(json.dumps([[str(r) for r in permissions], [str(r) for r in resources]]).encode("ascii")).hexdigest())
         self.append(dict(Sid=sid, Effect="Allow", Action=permissions, Resource=resources))
 
     def deny(self, permissions, resources, sid=None):
-        sid = sid or "Policy" + str(hashlib.sha224(json.dumps([permissions, resources]).encode("ascii")).hexdigest())
+        sid = sid or "Policy" + str(hashlib.sha224(json.dumps([[str(r) for r in permissions], [str(r) for r in resources]]).encode("ascii")).hexdigest())
         self.append(dict(Sid=sid, Effect="Deny", Action=permissions, Resource=resources))
 
     def apply(self, preset: "IAMPreset"):


### PR DESCRIPTION
*Problem*
When you’re passing object of type `Ref` (from troposphere) you will get:
```
TypeError: Object of type Ref is not JSON serializable
```