### PR TITLE
[serverless-python-requirements] Make plugin compatible with version `6.0.0`

### DIFF
--- a/serverless/service/plugins/python_requirements.py
+++ b/serverless/service/plugins/python_requirements.py
@@ -34,7 +34,7 @@ class PythonRequirements(Generic):
         export = dict(self)
         export.pop("name", None)
 
-        if not export.get("dockerImage"):
-            export["dockerImage"] = f"lambci/lambda:build-{service.provider.runtime}"
+        if not self.dockerImage:
+            export.pop("dockerImage", None)
 
         service.custom.pythonRequirements = export


### PR DESCRIPTION
With version `6.0.0` of `serverless-python-requirements` they switched to use official AWS docker images. More info can be found in https://github.com/serverless/serverless-python-requirements/pull/724

So we don’t need `lambci/lambda` anymore.

With this change everyone who is using `serverless-python-requirements` plugin and will update `serverless-builder`, would have to upgrade `serverless-python-requirements` itself.

I was considering two less breaking change approach like:

1. Introduce new plugin class
```
class PythonRequirements600 {

}
```

2. Modification of `PythonRequirements.__init__` and add `version` parameter

But to be honest I don’t think it’s worth to maintain this backward compatibility.