### PR TITLE
Allow dynamodb:BatchGetItem in IAM policies

### DIFF
--- a/docs/integrations/power_tools.md
+++ b/docs/integrations/power_tools.md
@@ -39,6 +39,7 @@ provider:
       - Sid: ServiceNameTestListIdempotencyFullAccess
         Effect: Allow
         Action:
+        - dynamodb:BatchGetItem
         - dynamodb:GetItem
         - dynamodb:Query
         - dynamodb:Scan

--- a/serverless/aws/iam/dynamodb.py
+++ b/serverless/aws/iam/dynamodb.py
@@ -10,6 +10,7 @@ class DynamoDBReader(IAMPreset):
     def apply(self, policy_builder: PolicyBuilder, sid=None):
         policy_builder.allow(
             permissions=[
+                "dynamodb:BatchGetItem",
                 "dynamodb:GetItem",
                 "dynamodb:Query",
                 "dynamodb:Scan",
@@ -64,6 +65,7 @@ class DynamoDBFullAccess(IAMPreset):
     def apply(self, policy_builder: PolicyBuilder, sid=None):
         policy_builder.allow(
             permissions=[
+                "dynamodb:BatchGetItem",
                 "dynamodb:GetItem",
                 "dynamodb:Query",
                 "dynamodb:Scan",


### PR DESCRIPTION
If something is already allowed to call GetItem then it should probably be allowed to call BatchGetItem too.