### PR TITLE
allow step function to use other lambda functions as task

### DIFF
--- a/serverless/aws/features/stepfunctions.py
+++ b/serverless/aws/features/stepfunctions.py
@@ -339,12 +339,7 @@ class StateMachine(YamlOrderedDict):
 
     
     def task(self, function=None, resource=None, name=None, end: Optional[bool] = None):
-        if function is not None and resource is None:
-            return self.definition.add(Task(function, end=end))
-        elif function is None and resource is not None:
-            return self.definition.add(Task(resource=resource, name=name, end=end))
-        else:
-            raise ValueError("Either 'function' or 'resource' must be provided, but not both.")
+        return self.definition.add(Task(function=function, resource=resource, name=name, end=end))
 
 
     def map(self, name, steps, **kwargs):

--- a/serverless/aws/features/stepfunctions.py
+++ b/serverless/aws/features/stepfunctions.py
@@ -337,8 +337,15 @@ class StateMachine(YamlOrderedDict):
         self.definition = Definition(description, auto_fallback, auto_catch)
         self.events = events or []
 
-    def task(self, function, end: Optional[bool] = None):
-        return self.definition.add(Task(function, end=end))
+    
+    def task(self, function=None, resource=None, name=None, end: Optional[bool] = None):
+        if function is not None and resource is None:
+            return self.definition.add(Task(function, end=end))
+        elif function is None and resource is not None:
+            return self.definition.add(Task(resource=resource, name=name, end=end))
+        else:
+            raise ValueError("Either 'function' or 'resource' must be provided, but not both.")
+
 
     def map(self, name, steps, **kwargs):
         return self.definition.add(Map(name, steps, **kwargs))

--- a/serverless/aws/features/stepfunctions.py
+++ b/serverless/aws/features/stepfunctions.py
@@ -237,11 +237,10 @@ class Branch(YamlOrderedDict):
 class Parallel(Stage):
     yaml_tag = "!Parallel"
 
-    def __init__(self, name, branches, end=False):
+    def __init__(self, name, branches):
         super().__init__("Parallel")
         self.name = name
         self.Branches = branches
-        self.End = end
 
     @property
     def id(self):
@@ -345,8 +344,8 @@ class StateMachine(YamlOrderedDict):
     def map(self, name, steps, **kwargs):
         return self.definition.add(Map(name, steps, **kwargs))
 
-    def parallel(self, name, branches, end):
-        return self.definition.add(Parallel(name=name, branches=branches, end=end))
+    def parallel(self, name, branches):
+        return self.definition.add(Parallel(name=name, branches=branches))
 
     def wait(
         self, name, seconds: int = None, timestamp: str = None, seconds_path: str = None, timestamp_path: str = None


### PR DESCRIPTION
1. currently, only functions defined in the same serverless.yml is allowed as tasks. This change is to allow step function to use other lambda functions as task.
2. Removing `End` since Parallel `End` property causes error during sls deploy.
https://www.serverless.com/plugins/serverless-step-functions#parallel

```
stepFunctions:
  stateMachines:
    yourParallelMachine:
      definition:
        Comment: "An example of the Amazon States Language using a parallel state to execute two branches at the same time."
        StartAt: Parallel
        States:
          Parallel:
            Type: Parallel
            Next: Final State
            Branches:
            - StartAt: Wait 20s
              States:
                Wait 20s:
                  Type: Wait
                  Seconds: 20
                  End: true
            - StartAt: Pass
              States:
                Pass:
                  Type: Pass
                  Next: Wait 10s
                Wait 10s:
                  Type: Wait
                  Seconds: 10
                  End: true
          Final State:
            Type: Pass
            End: true
```

