### PR TITLE
feature: Allow to define `LogGroup` for function

### DIFF
--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -98,7 +98,7 @@ class Function(YamlOrderedDict):
         if use_async_dlq:
             self.use_async_dlq()
 
-        log_group_properties = kwargs.pop("log_group", {}).get("Properties") if kwargs.get("log_group", {}).get("Properties") else dict(RetentionInDays=30)
+        log_group_properties = kwargs.pop("log_group", {}).get("Properties") or dict(RetentionInDays=30)
 
         log_group = dict(Type="AWS::Logs::LogGroup", Properties=log_group_properties)
         if service.has(Encryption):

--- a/serverless/aws/functions/generic.py
+++ b/serverless/aws/functions/generic.py
@@ -90,9 +90,6 @@ class Function(YamlOrderedDict):
         if idempotency:
             self.with_idempotency(idempotency)
 
-        for name, value in kwargs.items():
-            setattr(self, name, value)
-
         self.dlq = None
 
         if use_dlq:
@@ -101,13 +98,18 @@ class Function(YamlOrderedDict):
         if use_async_dlq:
             self.use_async_dlq()
 
-        log_group = dict(Type="AWS::Logs::LogGroup", Properties=dict(RetentionInDays=30))
+        log_group_properties = kwargs.pop("log_group", {}).get("Properties") if kwargs.get("log_group", {}).get("Properties") else dict(RetentionInDays=30)
+
+        log_group = dict(Type="AWS::Logs::LogGroup", Properties=log_group_properties)
         if service.has(Encryption):
             log_group["Properties"]["KmsKeyId"] = EncryptableResource.encryption_arn()
             if not service.regions:
                 log_group["DependsOn"] = [EncryptableResource.encryption_key_name() + "Alias"]
 
         service.resources.add(DummyResource(title=self.log_group_name(), **log_group))
+
+        for name, value in kwargs.items():
+            setattr(self, name, value)
 
     @property
     def iam(self):


### PR DESCRIPTION
This change allows to set `Properties` for `LogGroup` which is created for lambda function.

Real use cases for that can be when you want to modify default `30` days of `RetentionInDays` or add `DataProtectionPolicy`

Usage:

```python
service.builder.function.generic(
    “my-function”,
    “Handle requests",
    handler=“my_module.appsync.handler",
    log_group=dict(Properties=dict(RetentionInDays=3653))
)
```